### PR TITLE
Issue#10 make user login flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  def after_sign_in_path_for(resource)
+    new_userfeature_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
-  def after_sign_in_path_for(resource)
-    new_userfeature_path
-  end
+  protected
+    def after_sign_in_path_for(resource)
+      user_path(current_user)
+    end
 end

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -44,8 +44,8 @@ class UserfeaturesController < ApplicationController
   # PATCH/PUT /userfeatures/1.json
   def update
     respond_to do |format|
-      if @userfeature.update(userfeature_params)
-        format.html { redirect_to @userfeature, notice: 'Userfeature was successfully updated.' }
+      if @userfeature.update(userfeature_params) && @userfeature.user.update(userfeature_user_params)
+        format.html { redirect_to @userfeature.user, notice: 'Userfeature was successfully updated.' }
         format.json { render :show, status: :ok, location: @userfeature }
       else
         format.html { render :edit }

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -26,10 +26,12 @@ class UserfeaturesController < ApplicationController
   def create
     @userfeature = Userfeature.new(userfeature_params)
     @userfeature.user_id = current_user.id
+    @userfeature.user.name = userfeature_user_params[:name]
+    @userfeature.user.gender = userfeature_user_params[:gender]
 
     respond_to do |format|
-      if @userfeature.save
-        format.html { redirect_to @userfeature, notice: 'Userfeature was successfully created.' }
+      if @userfeature.save && @userfeature.user.save
+        format.html { redirect_to @userfeature.user, notice: 'Userfeature was successfully created.' }
         format.json { render :show, status: :created, location: @userfeature }
       else
         format.html { render :new }
@@ -71,5 +73,9 @@ class UserfeaturesController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def userfeature_params
       params.require(:userfeature).permit(:height, :weight, :age, :activity, :purpose, :total_calorie, :protein, :fat, :carbo)
+    end
+
+    def userfeature_user_params
+      params.require(:userfeature).permit(:name, :gender)
     end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+    def after_sign_up_path_for(resource)
+      new_userfeature_path
+    end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,5 @@
 <% if user_signed_in? %>
+  <%= link_to 'users', users_path %>
   <%= link_to 'userfeatures', userfeatures_path %>
   <%= link_to 'foodhistories', foodhistories_path %>
   <%= link_to 'logout', destroy_user_session_path, method: :delete %>

--- a/app/views/userfeatures/_form.html.erb
+++ b/app/views/userfeatures/_form.html.erb
@@ -12,6 +12,16 @@
   <% end %>
 
   <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :gender %>
+    <%= form.number_field :gender %>
+  </div>
+
+  <div class="field">
     <%= form.label :height %>
     <%= form.number_field :height %>
   </div>

--- a/app/views/userfeatures/index.html.erb
+++ b/app/views/userfeatures/index.html.erb
@@ -6,6 +6,7 @@
   <thead>
     <tr>
       <th>User</th>
+      <th>User_Name</th>
       <th>Height</th>
       <th>Weight</th>
       <th>Age</th>
@@ -23,6 +24,7 @@
     <% @userfeatures.each do |userfeature| %>
       <tr>
         <td><%= userfeature.user_id %></td>
+        <td><%= userfeature.user.name %></td>
         <td><%= userfeature.height %></td>
         <td><%= userfeature.weight %></td>
         <td><%= userfeature.age %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :foodhistories
   resources :userfeatures
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'users/registrations' }
   resources :users
   root "users#index"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
close #10 
Issue#10に関して以下の流れで実施しました。

1. login後のページ遷移先を変更
    - after_sign_in_path_forを利用
    - userfeaturesのnewアクションに遷移
2. ユーザ情報入力画面でユーザ名・性別を入力可能な形に変更
    - name, gender(users)をuserfeaturesのview(form)に追加
3. ユーザ名・性別を受け取って、DBに登録する処理を追加
    - userfeaturesのcontrollerに、name, gender(usersリソース)を受け取る処理を追加
      - strong parameterを利用
    - userfeaturesのcontroller (create, update)に、
name, gender(usersリソース)のDB保存処理を追加
4. ユーザ情報登録後の画面遷移先を、カレントユーザの詳細画面に変更
    - userfeaturesのcontroller (create, update)のリダイレクト先を、
new_userfeature_pathに指定