### PR TITLE
Issue #12 ユーザ情報から推奨カロリー等のデータ計算

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
+# User enum_help for japanese select form
+gem 'enum_help', '~> 0.0.17'
 # User devise for authentication
 gem 'devise', '~> 4.5.0'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.25)
@@ -233,6 +235,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise (~> 4.5.0)
+  enum_help (~> 0.0.17)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg
@@ -253,4 +256,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -27,7 +27,6 @@ class UserfeaturesController < ApplicationController
     @userfeature = Userfeature.new(userfeature_params)
     @userfeature.user_id = current_user.id
     @userfeature.user.gender = userfeature_user_params[:gender]
-    @userfeature.culculate_calorie_macro()
 
     respond_to do |format|
       if @userfeature.save && @userfeature.user.save
@@ -45,7 +44,7 @@ class UserfeaturesController < ApplicationController
   def update
     @userfeature.attributes = userfeature_params
     @userfeature.user.gender = userfeature_user_params[:gender]
-    @userfeature.culculate_calorie_macro()
+
     respond_to do |format|
       if @userfeature.save && @userfeature.user.save
         format.html { redirect_to @userfeature, notice: 'Userfeature was successfully updated.' }

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -25,11 +25,12 @@ class UserfeaturesController < ApplicationController
   # POST /userfeatures.json
   def create
     @userfeature = Userfeature.new(userfeature_params)
-    @userfeature.culculate_calorie_macro()
     @userfeature.user_id = current_user.id
+    @userfeature.user.gender = userfeature_user_params[:gender]
+    @userfeature.culculate_calorie_macro()
 
     respond_to do |format|
-      if @userfeature.save
+      if @userfeature.save && @userfeature.user.save
         format.html { redirect_to @userfeature, notice: 'Userfeature was successfully created.' }
         format.json { render :show, status: :created, location: @userfeature }
       else
@@ -42,8 +43,11 @@ class UserfeaturesController < ApplicationController
   # PATCH/PUT /userfeatures/1
   # PATCH/PUT /userfeatures/1.json
   def update
+    @userfeature.attributes = userfeature_params
+    @userfeature.user.gender = userfeature_user_params[:gender]
+    @userfeature.culculate_calorie_macro()
     respond_to do |format|
-      if @userfeature.update(userfeature_params)
+      if @userfeature.save && @userfeature.user.save
         format.html { redirect_to @userfeature, notice: 'Userfeature was successfully updated.' }
         format.json { render :show, status: :ok, location: @userfeature }
       else
@@ -72,5 +76,9 @@ class UserfeaturesController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def userfeature_params
       params.require(:userfeature).permit(:height, :weight, :age, :activity, :purpose, :total_calorie, :protein, :fat, :carbo)
+    end
+
+    def userfeature_user_params
+      params.require(:userfeature).permit(:gender)
     end
 end

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -25,6 +25,7 @@ class UserfeaturesController < ApplicationController
   # POST /userfeatures.json
   def create
     @userfeature = Userfeature.new(userfeature_params)
+    @userfeature.culculate_calorie_macro()
     @userfeature.user_id = current_user.id
 
     respond_to do |format|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,7 @@ class User < ApplicationRecord
   has_many :foodhistories
   # 性別の番号は以下に準拠
   # https://qiita.com/aoshirobo/items/32deb45cb8c8b87d65a4
-  # enum gender: { male: 1, female: 2, not_applicable: 9, not_known: 0 }
-  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9}
+  enum gender: { male: 1, female: 2, not_applicable: 9, not_known: 0 }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :userfeatures
   has_many :foodhistories
+  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9 }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,10 @@
 class User < ApplicationRecord
   has_many :userfeatures
   has_many :foodhistories
-  enum gender: { male: 1, female: 2, not_applicable: 9, not_known: 0 }
+  # 性別の番号は以下に準拠
+  # https://qiita.com/aoshirobo/items/32deb45cb8c8b87d65a4
+  # enum gender: { male: 1, female: 2, not_applicable: 9, not_known: 0 }
+  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9}
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :userfeatures
   has_many :foodhistories
-  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9 }
+  enum gender: { male: 1, female: 2, not_applicable: 9, not_known: 0 }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -1,3 +1,47 @@
 class Userfeature < ApplicationRecord
   belongs_to :user
+  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9 }
+  enum activity: { high: 0, middle: 1, low: 2 }
+  enum purpose: { increase: 0, maintain: 1, loss: 2 }
+
+# カロリーやマクロ栄養素の計算式に関しては、以下のURLの”計算の解説”を参照
+# https://dietgenius.jp/macro-nutrient-calculator/#1492304410953-fc2d4b82-8b8c
+  def culculate_calorie_macro
+    culculate_calorie()
+    culculate_macro()
+  end
+
+  def culculate_calorie
+    gender_num = user.gender == 'male' ? 5 : -161
+    activity_val = activity_value()
+    purpose_val =  purpose_value()
+    basic_calorie = (10 * weight) + (6.25 * height) -
+                    (5 * age) + gender_num
+    self.total_calorie = basic_calorie * activity_val * purpose_val
+  end
+
+  def culculate_macro
+    self.protein = weight * 2
+    self.fat = total_calorie / (4 * 9)
+    self.carbo = (total_calorie -
+                     (protein * 4) - (fat * 9)) / 4
+  end
+
+  def activity_value
+    case self.activity
+    when 'low' then 1.2
+    when 'middle' then 1.55
+    when 'high' then 1.725
+    else 1.2
+    end
+  end
+
+  def purpose_value
+    case self.purpose
+    when 'loss' then 0.8
+    when 'maintain' then 1
+    when 'increase' then 1.2
+    else 1.2
+    end
+  end
 end

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -1,7 +1,10 @@
 class Userfeature < ApplicationRecord
   belongs_to :user
+  before_save :culculate_calorie_macro
   enum activity: { high: 0, middle: 1, low: 2 }
   enum purpose: { increase: 0, maintain: 1, loss: 2 }
+
+  private
 
 # カロリーやマクロ栄養素の計算式に関しては、以下のURLの”計算の解説”を参照
 # https://dietgenius.jp/macro-nutrient-calculator/#1492304410953-fc2d4b82-8b8c
@@ -10,7 +13,6 @@ class Userfeature < ApplicationRecord
     culculate_macro()
   end
 
-  # private
 
   def culculate_calorie
     gender_num = self.user.gender == 'male' ? 5 : -161

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -1,6 +1,6 @@
 class Userfeature < ApplicationRecord
   belongs_to :user
-  before_save :culculate_calorie_macro
+  before_validation :culculate_calorie_macro
   enum activity: { high: 0, middle: 1, low: 2 }
   enum purpose: { increase: 0, maintain: 1, loss: 2 }
 

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -10,6 +10,8 @@ class Userfeature < ApplicationRecord
     culculate_macro()
   end
 
+  # private
+
   def culculate_calorie
     gender_num = self.user.gender == 'male' ? 5 : -161
     activity_val = activity_value()

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -1,6 +1,5 @@
 class Userfeature < ApplicationRecord
   belongs_to :user
-  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9 }
   enum activity: { high: 0, middle: 1, low: 2 }
   enum purpose: { increase: 0, maintain: 1, loss: 2 }
 
@@ -12,7 +11,7 @@ class Userfeature < ApplicationRecord
   end
 
   def culculate_calorie
-    gender_num = user.gender == 'male' ? 5 : -161
+    gender_num = self.user.gender == 'male' ? 5 : -161
     activity_val = activity_value()
     purpose_val =  purpose_value()
     basic_calorie = (10 * weight) + (6.25 * height) -

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -13,9 +13,8 @@ class Userfeature < ApplicationRecord
     culculate_macro()
   end
 
-
   def culculate_calorie
-    gender_num = self.user.gender == 'male' ? 5 : -161
+    gender_num = user.male? ? 5 : -161
     activity_val = activity_value()
     purpose_val =  purpose_value()
     basic_calorie = (10 * weight) + (6.25 * height) -
@@ -31,20 +30,14 @@ class Userfeature < ApplicationRecord
   end
 
   def activity_value
-    case self.activity
-    when 'low' then 1.2
-    when 'middle' then 1.55
-    when 'high' then 1.725
-    else 1.2
-    end
+    return 1.2 if low?
+    return 1.55 if middle?
+    return 1.725 if high?
   end
 
   def purpose_value
-    case self.purpose
-    when 'loss' then 0.8
-    when 'maintain' then 1
-    when 'increase' then 1.2
-    else 1.2
-    end
+    return 0.8 if loss?
+    return 1 if maintain?
+    return 1.2 if increase?
   end
 end

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -30,14 +30,14 @@ class Userfeature < ApplicationRecord
   end
 
   def activity_value
-    return 1.2 if low?
     return 1.55 if middle?
     return 1.725 if high?
+    1.2
   end
 
   def purpose_value
-    return 0.8 if loss?
     return 1 if maintain?
     return 1.2 if increase?
+    0.8
   end
 end

--- a/app/views/userfeatures/_form.html.erb
+++ b/app/views/userfeatures/_form.html.erb
@@ -12,6 +12,11 @@
   <% end %>
 
   <div class="field">
+    <%= form.label :gender %><br>
+    <%= form.select :gender, [['男性','male'], ['女性','female'], ['その他','not_applicable'], ['無回答','not_known']], class: 'form-control' %><br> 
+  </div>
+
+  <div class="field">
     <%= form.label :height %>
     <%= form.number_field :height %>
   </div>
@@ -27,33 +32,20 @@
   </div>
 
   <div class="field">
-    <%= form.label :activity %>
-    <%= form.number_field :activity %>
+    <%= form.label :activity%><br>
+    <%= form.select :activity, [['高い','high'], ['普通','middle'], ['低い','low']], class: 'form-control' %><br> 
   </div>
 
-  <div class="field">
-    <%= form.label :purpose %>
-    <%= form.number_field :purpose %>
-  </div>
+Activityの目安
+<ul>
+<li>activity = 低い：座り仕事が多い</li>
+<li>activity = 普通：立ち仕事や重労働が多い</li>
+<li>activity = 低い：立ち仕事や重労働が多い＆運動もしている</li>
+</ul>
 
   <div class="field">
-    <%= form.label :total_calorie %>
-    <%= form.number_field :total_calorie %>
-  </div>
-
-  <div class="field">
-    <%= form.label :protein %>
-    <%= form.number_field :protein %>
-  </div>
-
-  <div class="field">
-    <%= form.label :fat %>
-    <%= form.number_field :fat %>
-  </div>
-
-  <div class="field">
-    <%= form.label :carbo %>
-    <%= form.number_field :carbo %>
+    <%= form.label :purpose%><br>
+    <%= form.select :purpose, [['増量','increase'], ['維持','maintain'], ['減量','loss']], class: 'form-control' %><br> 
   </div>
 
   <div class="actions">

--- a/app/views/userfeatures/_form.html.erb
+++ b/app/views/userfeatures/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= form.label :gender %><br>
-    <%= form.select :gender, [['男性','male'], ['女性','female'], ['その他','not_applicable'], ['無回答','not_known']], class: 'form-control' %><br> 
+    <%= form.select :gender, [['男性','male'], ['女性','female'], ['その他','not_applicable'], ['無回答','not_known']], class: 'form-control' %><br>
   </div>
 
   <div class="field">
@@ -33,7 +33,7 @@
 
   <div class="field">
     <%= form.label :activity%><br>
-    <%= form.select :activity, [['高い','high'], ['普通','middle'], ['低い','low']], class: 'form-control' %><br> 
+    <%= form.select :activity, [['高い','high'], ['普通','middle'], ['低い','low']], class: 'form-control' %><br>
   </div>
 
 Activityの目安
@@ -45,7 +45,7 @@ Activityの目安
 
   <div class="field">
     <%= form.label :purpose%><br>
-    <%= form.select :purpose, [['増量','increase'], ['維持','maintain'], ['減量','loss']], class: 'form-control' %><br> 
+    <%= form.select :purpose, [['増量','increase'], ['維持','maintain'], ['減量','loss']], class: 'form-control' %><br>
   </div>
 
   <div class="actions">

--- a/app/views/userfeatures/_form.html.erb
+++ b/app/views/userfeatures/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= form.label :gender %><br>
-    <%= form.select :gender, [['男性','male'], ['女性','female'], ['その他','not_applicable'], ['無回答','not_known']], class: 'form-control' %><br>
+    <%= form.select :gender, User.genders_i18n.invert %>
   </div>
 
   <div class="field">
@@ -33,7 +33,7 @@
 
   <div class="field">
     <%= form.label :activity%><br>
-    <%= form.select :activity, [['高い','high'], ['普通','middle'], ['低い','low']], class: 'form-control' %><br>
+    <%= form.select :activity, Userfeature.activities_i18n.invert %>
   </div>
 
 Activityの目安
@@ -45,7 +45,7 @@ Activityの目安
 
   <div class="field">
     <%= form.label :purpose%><br>
-    <%= form.select :purpose, [['増量','increase'], ['維持','maintain'], ['減量','loss']], class: 'form-control' %><br>
+    <%= form.select :purpose, Userfeature.purposes_i18n.invert %>
   </div>
 
   <div class="actions">

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,4 @@ module MacroShare
         view_specs: false
     end
   end
-
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.config.available_locales = :ja
+I18n.default_locale = :ja

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  enums:
+    user:
+      gender:
+        male: 男性
+        female: 女性
+        not_applicable: その他
+        not_known: 未回答
+    userfeature:
+      activity:
+        high: 高い
+        middle: 普通
+        low: 低い
+      purpose:
+        increase: 増量
+        maintain: 維持
+        loss: 減量


### PR DESCRIPTION
fix #12
@ms2sato 

Issue #12対応しました。ご確認お願いします。

# 概要
ユーザ情報から
- 推奨カロリー
- 推奨マクロ栄養素(タンパク質、脂質、炭水化物)

を算出するロジックを追加(Issue #12 )

算出方法のロジックは以下のURLの”計算の解説”を参照
https://dietgenius.jp/macro-nutrient-calculator/#1492304410953-fc2d4b82-8b8

# 変更内容
## Issue #12のメイン
- userfeatureのformから以下を削除
(他のユーザ情報から自動的に算出される)
  - total_calorie, protein, fat, carbo
- 以下のattributeにenumを設定
  - user modelのgender
  - userfeature modelのactivity, purpose
- 以下のattributeに対応するformの要素をselectに変更
(enumの設定に対応)
  - gender, activity, purpose
- userfeature modelに以下のロジックを追加
  - 推奨カロリー＆推奨マクロ栄養素(タンパク質、脂質、炭水化物)の算出
= calculate_calorie_macro() および関連するprivate method
  - 具体的にはtotal_calorie, protein, fat, carboが算出対象
- userfeatures controllerのcreate/updateに、
calculate_calorie_macro()を呼び出す処理を追加する事
## その他の修正
- userfeaturesのformからgenderを更新する方法は、
Issue#10で使った力技を用いています。(accept_nested_attributes_forを使わない)
  - 後で一括して修正したいと考えています。

# 確認内容
- 新規にuserfeatureを作成した結果、
total_calorie, protein, fat, carboが自動的に算出されるようになる事
- 作成済みのuserfeatureを編集した際、その内容に応じて、
total_calorie, protein, fat, carboが再計算される事
   
# 既知の制限
- users のforｍからはgenderを更新できません。
  - enumに対応したフォームになっていないため。
  - どこかの段階で、usersのformからgender 自体を削除します。

# 備考
- このbranchは現行のmasterから派生しています。
(Issue #10の修正が含まれていない)
- 内容的にIssue#10とコンフリクトするかもしれませんが、
学習目的であえてこのまま行っていいのでは？と思っています。
(土曜日にいただいたコメントより)