### PR TITLE
Issue#20 Culculate calorie macro gender

### DIFF
--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -79,9 +79,11 @@ class UserfeaturesController < ApplicationController
       )
     end
 
-    # userfeaturesが更新されない＆user(のgender)が更新される場合は、
-    # userからculcurate_calorie_macroを行う必要がある。
-    # user側で対象のuserfeatureを判別できるようにするために、
+    # <Issue#20>
+    # userfeaturesのattributesは更新されないが、
+    # user(のgender)が更新される場合は、
+    # user modelのcall backからculcurate_calorie_macroを行う。
+    # user modelで対象のuserfeatureを判別できるようにするために、
     # @user.userfeature_idを設定する。
     def confirm_userfeature_update_skip
       userfeature_params = params[:user][:userfeatures_attributes][:'0']
@@ -89,18 +91,8 @@ class UserfeaturesController < ApplicationController
     end
 
     def no_userfeature_update?(userfeature_params)
-      # 雑な実装。もう少しスマートな形に変えたい。
-      if (
-        @userfeature.id.to_s == userfeature_params[:id] \
-        && @userfeature.height.to_s == userfeature_params[:height] \
-        && @userfeature.weight.to_s == userfeature_params[:weight] \
-        && @userfeature.age.to_s == userfeature_params[:age] \
-        && @userfeature.activity.to_s == userfeature_params[:activity] \
-        && @userfeature.purpose.to_s == userfeature_params[:purpose] \
-        )
-        true
-      else
-        false
-      end
+      # 本来は@userfeatureのソートなり要素の削除なりした上でrejectの利用が必要そうだが、
+      # このケースではuserfeature_paramsの構造上必要なかった
+      userfeature_params.reject { |k, v| v == @userfeature[k].to_s }.keys.blank?
     end
 end

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -14,7 +14,7 @@ class UserfeaturesController < ApplicationController
 
   # GET /userfeatures/new
   def new
-    @userfeature = Userfeature.new
+    @userfeature = current_user.userfeatures.build
   end
 
   # GET /userfeatures/1/edit
@@ -24,14 +24,11 @@ class UserfeaturesController < ApplicationController
   # POST /userfeatures
   # POST /userfeatures.json
   def create
-    @userfeature = Userfeature.new(userfeature_params)
-    @userfeature.user_id = current_user.id
-    @userfeature.user.name = userfeature_user_params[:name]
-    @userfeature.user.gender = userfeature_user_params[:gender]
+    @user = current_user
 
     respond_to do |format|
-      if @userfeature.save && @userfeature.user.save
-        format.html { redirect_to @userfeature.user, notice: 'Userfeature was successfully created.' }
+      if @user.update(nested_user_params)
+        format.html { redirect_to @user, notice: 'Userfeature was successfully created.' }
         format.json { render :show, status: :created, location: @userfeature }
       else
         format.html { render :new }
@@ -43,11 +40,10 @@ class UserfeaturesController < ApplicationController
   # PATCH/PUT /userfeatures/1
   # PATCH/PUT /userfeatures/1.json
   def update
-    @userfeature.attributes = userfeature_params
-    @userfeature.user.gender = userfeature_user_params[:gender]
+    @user = current_user
 
     respond_to do |format|
-      if @userfeature.update(userfeature_params) && @userfeature.user.update(userfeature_user_params)
+      if @user.update(nested_user_params)
         format.html { redirect_to @userfeature.user, notice: 'Userfeature was successfully updated.' }
         format.json { render :show, status: :ok, location: @userfeature }
       else
@@ -74,11 +70,11 @@ class UserfeaturesController < ApplicationController
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
-    def userfeature_params
-      params.require(:userfeature).permit(:height, :weight, :age, :activity, :purpose, :total_calorie, :protein, :fat, :carbo)
-    end
-
-    def userfeature_user_params
-      params.require(:userfeature).permit(:name, :gender)
+    def nested_user_params
+      params.require(:user).permit(
+        :name,
+        :gender,
+        userfeatures_attributes: [:id, :height, :weight, :age, :activity, :purpose]
+      )
     end
 end

--- a/app/controllers/userfeatures_controller.rb
+++ b/app/controllers/userfeatures_controller.rb
@@ -42,6 +42,7 @@ class UserfeaturesController < ApplicationController
   def update
     @user = current_user
 
+    confirm_userfeature_update_skip()
     respond_to do |format|
       if @user.update(nested_user_params)
         format.html { redirect_to @userfeature.user, notice: 'Userfeature was successfully updated.' }
@@ -76,5 +77,30 @@ class UserfeaturesController < ApplicationController
         :gender,
         userfeatures_attributes: [:id, :height, :weight, :age, :activity, :purpose]
       )
+    end
+
+    # userfeaturesが更新されない＆user(のgender)が更新される場合は、
+    # userからculcurate_calorie_macroを行う必要がある。
+    # user側で対象のuserfeatureを判別できるようにするために、
+    # @user.userfeature_idを設定する。
+    def confirm_userfeature_update_skip
+      userfeature_params = params[:user][:userfeatures_attributes][:'0']
+      @user.userfeature_id = userfeature_params[:id] if no_userfeature_update?(userfeature_params)
+    end
+
+    def no_userfeature_update?(userfeature_params)
+      # 雑な実装。もう少しスマートな形に変えたい。
+      if (
+        @userfeature.id.to_s == userfeature_params[:id] \
+        && @userfeature.height.to_s == userfeature_params[:height] \
+        && @userfeature.weight.to_s == userfeature_params[:weight] \
+        && @userfeature.age.to_s == userfeature_params[:age] \
+        && @userfeature.activity.to_s == userfeature_params[:activity] \
+        && @userfeature.purpose.to_s == userfeature_params[:purpose] \
+        )
+        true
+      else
+        false
+      end
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,12 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # <Issue#20>
+  # userfeatures_controllerから、userfeature_idを受け取った場合は、
+  # user modelからculcurate_calorie_macroを行う
+  # 詳細はuserfeatures_controllerの、confirm_userfeature_update_skipメソッドを参照
   def update_calorie_macro
-    if userfeature_id.present?
-      userfeature = userfeatures.find(userfeature_id)
-      userfeature.culculate_calorie_macro
-      userfeature.save
-    end
+    userfeatures.find(userfeature_id).save if userfeature_id.present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   has_many :userfeatures
   has_many :foodhistories
   accepts_nested_attributes_for :userfeatures
+  before_validation :update_calorie_macro
+  attr_accessor :userfeature_id
 
   # 性別の番号は以下に準拠
   # https://qiita.com/aoshirobo/items/32deb45cb8c8b87d65a4
@@ -10,4 +12,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  def update_calorie_macro
+    if userfeature_id.present?
+      userfeature = userfeatures.find(userfeature_id)
+      userfeature.culculate_calorie_macro
+      userfeature.save
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :userfeatures
   has_many :foodhistories
+  accepts_nested_attributes_for :userfeatures
+
   # 性別の番号は以下に準拠
   # https://qiita.com/aoshirobo/items/32deb45cb8c8b87d65a4
   enum gender: { male: 1, female: 2, not_applicable: 9, not_known: 0 }

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -4,15 +4,18 @@ class Userfeature < ApplicationRecord
   enum activity: { high: 0, middle: 1, low: 2 }
   enum purpose: { increase: 0, maintain: 1, loss: 2 }
 
-  private
 
-# カロリーやマクロ栄養素の計算式に関しては、以下のURLの”計算の解説”を参照
-# https://dietgenius.jp/macro-nutrient-calculator/#1492304410953-fc2d4b82-8b8c
+  # カロリーやマクロ栄養素の計算式に関しては、以下のURLの”計算の解説”を参照
+  # https://dietgenius.jp/macro-nutrient-calculator/#1492304410953-fc2d4b82-8b8c
+
+  # culculate_calorie_macroはuser modelからも利用するため
+  # privateには指定しない
   def culculate_calorie_macro
     culculate_calorie()
     culculate_macro()
   end
 
+  private
   def culculate_calorie
     gender_num = user.male? ? 5 : -161
     activity_val = activity_value()

--- a/app/models/userfeature.rb
+++ b/app/models/userfeature.rb
@@ -4,18 +4,15 @@ class Userfeature < ApplicationRecord
   enum activity: { high: 0, middle: 1, low: 2 }
   enum purpose: { increase: 0, maintain: 1, loss: 2 }
 
+  private
 
   # カロリーやマクロ栄養素の計算式に関しては、以下のURLの”計算の解説”を参照
   # https://dietgenius.jp/macro-nutrient-calculator/#1492304410953-fc2d4b82-8b8c
-
-  # culculate_calorie_macroはuser modelからも利用するため
-  # privateには指定しない
   def culculate_calorie_macro
     culculate_calorie()
     culculate_macro()
   end
 
-  private
   def culculate_calorie
     gender_num = user.male? ? 5 : -161
     activity_val = activity_value()

--- a/app/views/userfeatures/_form.html.erb
+++ b/app/views/userfeatures/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: userfeature, local: true) do |form| %>
+<!-- 多分暫定なのでインデントはこのまま -->
   <% if userfeature.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(userfeature.errors.count, "error") %> prohibited this userfeature from being saved:</h2>
@@ -21,39 +21,44 @@
     <%= form.select :gender, User.genders_i18n.invert %>
   </div>
 
-  <div class="field">
-    <%= form.label :height %>
-    <%= form.number_field :height %>
-  </div>
+  <%= form.fields_for :userfeatures, userfeature do |userfeature_f| %>
+    <div class="field">
+        <%= userfeature_f.hidden_field :id, value: userfeature.id %>
+     </div>
 
-  <div class="field">
-    <%= form.label :weight %>
-    <%= form.number_field :weight %>
-  </div>
+    <div class="field">
+      <%= userfeature_f.label :height %>
+      <%= userfeature_f.number_field :height %>
+    </div>
 
-  <div class="field">
-    <%= form.label :age %>
-    <%= form.number_field :age %>
-  </div>
+    <div class="field">
+      <%= userfeature_f.label :weight %>
+      <%= userfeature_f.number_field :weight %>
+    </div>
 
-  <div class="field">
-    <%= form.label :activity%><br>
-    <%= form.select :activity, Userfeature.activities_i18n.invert %>
-  </div>
+    <div class="field">
+      <%= userfeature_f.label :age %>
+      <%= userfeature_f.number_field :age %>
+    </div>
 
-Activityの目安
-<ul>
-<li>activity = 低い：座り仕事が多い</li>
-<li>activity = 普通：立ち仕事や重労働が多い</li>
-<li>activity = 低い：立ち仕事や重労働が多い＆運動もしている</li>
-</ul>
+    <div class="field">
+      <%= userfeature_f.label :activity%><br>
+      <%= userfeature_f.select :activity, Userfeature.activities_i18n.invert %>
+    </div>
 
-  <div class="field">
-    <%= form.label :purpose%><br>
-    <%= form.select :purpose, Userfeature.purposes_i18n.invert %>
-  </div>
+    Activityの目安
+    <ul>
+    <li>activity = 低い：座り仕事が多い</li>
+    <li>activity = 普通：立ち仕事や重労働が多い</li>
+    <li>activity = 低い：立ち仕事や重労働が多い＆運動もしている</li>
+    </ul>
+
+    <div class="field">
+      <%= userfeature_f.label :purpose%><br>
+      <%= userfeature_f.select :purpose, Userfeature.purposes_i18n.invert %>
+    </div>
+  <% end %>
 
   <div class="actions">
     <%= form.submit %>
   </div>
-<% end %>

--- a/app/views/userfeatures/edit.html.erb
+++ b/app/views/userfeatures/edit.html.erb
@@ -1,6 +1,8 @@
 <h1>Editing Userfeature</h1>
 
-<%= render 'form', userfeature: @userfeature %>
+<%= form_with(model: current_user, local: true, url: userfeature_path, method: :patch) do |form| %>
+<%= render 'form', userfeature: @userfeature, form: form %>
+<% end %>
 
 <%= link_to 'Show', @userfeature %> |
 <%= link_to 'Back', userfeatures_path %>

--- a/app/views/userfeatures/new.html.erb
+++ b/app/views/userfeatures/new.html.erb
@@ -1,5 +1,7 @@
 <h1>New Userfeature</h1>
 
-<%= render 'form', userfeature: @userfeature %>
+<%= form_with(model: current_user, local: true, url: userfeatures_path, method: :post) do |form| %>
+<%= render 'form', userfeature: @userfeature, form: form %>
+<% end %>
 
 <%= link_to 'Back', userfeatures_path %>


### PR DESCRIPTION
close #20 
@ms2sato 

Issue #20 userfeatureから性別のみ変えた際に、推奨カロリー等が再計算されない
を修正しました。

コミット及び修正がたくさんありますが、
最初にrecomendation_calorie_pfc_logic(masterへのPR中)をmergeした影響です。

”Issue #20 Fix culculate calorie macro logic for only changing gender"
以降の3つのコミットのみご確認いただければ。

# 修正内容
- user modelに"attr_accessor :userfeature_id"を追加
- userfeatures_controllerに以下の処理を追加
  - update actionでconfirm_userfeature_update_skipメソッドの呼び出し処理を追加
  - confirm_userfeature_update_skipメソッド
     - 受け取ったparameterのうち、userfeature関連のものに更新がない場合、
user model の @user.userfeature_idにuserfeatureのidを渡す
- user modelにbefore_validation コールバック = update_calorie_macroメソッドを追加
  - update_calorie_macroメソッド
     - userfeature_idが空でない場合に、userfeaturesのsaveを行う。
(結果 update_calorie_macroメソッドを実行する)

## 確認内容
- userfeatureからgenderのみアップデートで、calorie等が更新されること
- gender & userfeatureのパラメータ更新で、calorie等が更新されること
- userfeatureの新規登録ができること
- コンソールから２重でSQLが発行されていないこと