### PR TITLE
Issue #36 Improve image upload(carrierwave and nested form)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /config/database.yml
+
+# Ignore updated images
+/public/uploads

--- a/app/controllers/foodhistories_controller.rb
+++ b/app/controllers/foodhistories_controller.rb
@@ -74,7 +74,7 @@ class FoodhistoriesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def foodhistory_params
-      params.require(:foodhistory).permit(:name, :calorie, :protein, :fat, :carbo, :image_name, :mode, foodhistory_images_attributes: [:avatar])
-
+      params.require(:foodhistory).permit(:name, :calorie, :protein, :fat, :carbo, :image_name, :mode,
+        foodhistory_images_attributes: [:id, :avatar, :avatar_cache, :_destroy])
     end
 end

--- a/app/controllers/foodhistories_controller.rb
+++ b/app/controllers/foodhistories_controller.rb
@@ -17,12 +17,12 @@ class FoodhistoriesController < ApplicationController
   def new
     @foodhistory = params[:reuse_record_id] ?
      Foodhistory.find(params[:reuse_record_id]).dup : Foodhistory.new
-    @foodhistory_image = @foodhistory.foodhistory_images.build
+    @foodhistory.foodhistory_images.build
   end
 
   # GET /foodhistories/1/edit
   def edit
-    @foodhistory_image = @foodhistory.foodhistory_images.build
+    @foodhistory.foodhistory_images.build
   end
 
   # POST /foodhistories

--- a/app/models/foodhistory.rb
+++ b/app/models/foodhistory.rb
@@ -1,9 +1,12 @@
 class Foodhistory < ApplicationRecord
+  validates :name, presence: true
   belongs_to :user
   has_many :likes
   has_many :users, through: :likes
   has_many :foodhistory_images, dependent: :destroy
-  accepts_nested_attributes_for :foodhistory_images
+  accepts_nested_attributes_for :foodhistory_images,
+    allow_destroy: true,
+    reject_if: proc { |attributes| attributes['avatar'].blank? && attributes['avatar_cache'].blank? }
   enum mode: { pri: 0, pub: 1 }
   scope :daily_basis, -> (user, date) { where(user: user, created_at: date.beginning_of_day...date.end_of_day) }
 

--- a/app/views/foodhistories/_form.html.erb
+++ b/app/views/foodhistories/_form.html.erb
@@ -41,17 +41,15 @@
     <%= form.number_field :carbo %>
   </div>
 
-  <%= form.fields_for :foodhistory_images, foodhistory_image do |foodhistory_image_field| %>
-      <%= form.label :avatar %>
-      <%= foodhistory_image_field.file_field :avatar %>
-  <% end %>
-
-  <% foodhistory.foodhistory_images.each do |foodhistory_image| %>
-    <br>
-    <% unless foodhistory_image.avatar.file.nil? %>
-      <%= image_tag foodhistory_image.avatar.url  %>
-      <%= link_to "destroy", foodhistory_image_path(foodhistory_image), method: :delete %>
+  <%= form.fields_for :foodhistory_images do |i| %>
+    <%= i.label :avatar, style: 'padding-top: 30px;' %>
+    <%= i.hidden_field :avatar_cache %><!-- for redisplay on validation error -->
+    <% if i.object&.avatar.present? %>
+      <%= image_tag i.object.avatar.url, width: '200'  %>
+      delete<%= i.check_box :_destroy %>
     <% end %>
+    <br>
+    <%= i.file_field :avatar %>
   <% end %>
 
   <div class="actions">

--- a/app/views/foodhistories/_form.html.erb
+++ b/app/views/foodhistories/_form.html.erb
@@ -44,7 +44,7 @@
   <%= form.fields_for :foodhistory_images do |i| %>
     <%= i.label :avatar, style: 'padding-top: 30px;' %>
     <%= i.hidden_field :avatar_cache %><!-- for redisplay on validation error -->
-    <% if i.object&.avatar.present? %>
+    <% if i.object.avatar.present? %>
       <%= image_tag i.object.avatar.url, width: '200'  %>
       delete<%= i.check_box :_destroy %>
     <% end %>

--- a/app/views/foodhistories/edit.html.erb
+++ b/app/views/foodhistories/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing Foodhistory</h1>
 
-<%= render 'form', foodhistory: @foodhistory, foodhistory_image: @foodhistory_image %>
+<%= render 'form', foodhistory: @foodhistory %>
 
 <%= link_to 'Show', @foodhistory %> |
 <%= link_to 'Back', foodhistories_path %>

--- a/app/views/foodhistories/new.html.erb
+++ b/app/views/foodhistories/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New Foodhistory</h1>
 
-<%= render 'form', foodhistory: @foodhistory , foodhistory_image: @foodhistory_image%>
+<%= render 'form', foodhistory: @foodhistory %>
 
 <%= link_to 'Back', foodhistories_path %>

--- a/app/views/foodhistories/show.html.erb
+++ b/app/views/foodhistories/show.html.erb
@@ -29,7 +29,7 @@
   <strong>Image name:</strong>
   <br>
   <% @foodhistory.foodhistory_images.each do |foodhistory_image| %>
-    <%= image_tag foodhistory_image.avatar.url  %>
+    <%= image_tag foodhistory_image.avatar.url, width: '200' %>
     <br>
   <% end %>
 </p>


### PR DESCRIPTION
"Issue#36 画像アップロードを適切にする"に関して、
修正を行いました。
確認をお願いします！

## 修正内容
### 画像の削除
- fields_for(foodhistory_imageのform)に関して、collectionを扱う形に変更する
  - 参考：https://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for
    "... fields_for call will be repeated for each instance in the collection:"
- accepts_nested_attributes_for :foodhistory_imagesに、
  allow_destroy: true を追加
- accepts_nested_attributes_for :foodhistory_imagesに、
  reject_if: proc { |attributes| attributes['avatar'].blank? }
  を追加
  - 画像の削除とは直接関係無いが、fields_forに対する修正の関係で、
    この修正を行なわないと、editの度に空のfoodhistory_imageが増えてしまう 
- formに _destroy: '1' を送るチェックボックスを追加
  (DB登録済み画像を表示するタイミングで)
- controllerに, :id, :_destroyを追加

### バリデーションエラーが発生した時も画像を保持
- 前提：以下の手順で起こる不具合(carrierwaveとしては仕様)への対応
  1. foodhistory nameにvalidationとして"presence: true"を設定
  2. foodhistory new/edit時、
  name を空 & 画像はアップロード の状態で登録を試みる
  3. validationエラー発生＆form上画像はアップロード済みのように見えることを確認
  4. nameに適当な文字をいれた上で、再度登録
  -> foodhistoryの保存には成功するが、画像は登録されていない
- 以下修正内容
  - https://github.com/carrierwaveuploader/carrierwave
    の Making uploads work across form redisplaysに従って、
    <%= f.hidden_field :avatar_cache %>を追加
  - https://github.com/carrierwaveuploader/carrierwave/issues/670#issuecomment-5456573
    https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Making-uploads-work-across-form-redisplays-with-accept_nested_attributes_for
    に従って、reject_ifに attributes['avatar_cache'].blank? を追加
    - validation発生時は、":avatarは空" ＆ ":avatar_cacheに画像情報"
    の形になるため、上の設定が必要

## 確認内容
- 画像を複数アップロードした状態で、チェックボックスを使ってまとめて画像の削除が行えること
- 上記"前提"に記載した不具合が発生しないこと

## 疑問点
- https://github.com/CircleAround/rails_idioms-multiple_images_by_carrierwave/
  のformの中で、if i.object&.path.present? という形で&.を用いている箇所がある認識です。
  - i.objectがnilである状況のカバーという認識です。
  どういう状況で"i.objectがnil"は発生しますでしょうか？
(考えてみたのですが、思いつきませんでした。。。)
  - もしくは、if の条件を"i.object.path"という形にする際は、
  (ある種お作法的に?)&.を使った方が良い、という内容でしょうか？